### PR TITLE
Make plugin config optional

### DIFF
--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -39,6 +39,24 @@ function clientRender(element) {
   }
 }
 
+test('without UniversalEvents', t => {
+  const Hello = () => <div>Hello</div>;
+  const element = (
+    <div>
+      <Route path="/" trackingId="home" component={Hello} />
+      <Route path="/lol" component={Hello} />
+    </div>
+  );
+  const ctx = getMockCtx({
+    url: '/',
+    element,
+  });
+  const plugin = getRouter();
+  runPlugin(plugin, ctx);
+  t.notEquals(ctx.element, element, 'wraps ctx.element');
+  t.end();
+});
+
 test('events with trackingId', t => {
   const Hello = () => <div>Hello</div>;
   const element = (

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -26,7 +26,7 @@ import {Router as BrowserRouter} from './browser';
 import {html, unescape} from 'fusion-core';
 
 const Router = __NODE__ ? ServerRouter : BrowserRouter;
-export default function getRouter({UniversalEvents}) {
+export default function getRouter({UniversalEvents} = {}) {
   return function middleware(ctx, next) {
     if (!ctx.element) {
       return next();


### PR DESCRIPTION
An error is currently thrown when following the documentation because a valid configuration object is not passed in.

Fixes #19