### PR TITLE
Add Token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ app.register(UniversalEventsToken, UniversalEvents);
 
 Name | Type | Description
 -|-|-
-`UniversalEventsToken` | `UniversalEvents` | An event emitter plugin to emit stats to, such as the one provided by [`fusion-plugin-universal-events`](https://github.com/fusionjs/fusion-plugin-universal-events).
+`UniversalEventsToken` | `UniversalEvents` | An event emitter plugin to emit routing events to, such as the one provided by [`fusion-plugin-universal-events`](https://github.com/fusionjs/fusion-plugin-universal-events).
 
 
 #### `Router`

--- a/README.md
+++ b/README.md
@@ -70,15 +70,18 @@ export default root;
 
 #### Dependency registration
 
-```jsx
-import Router from 'fusion-plugin-react-router';
+```js
 import UniversalEvents, {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
-app.register(Router);
 app.register(UniversalEventsToken, UniversalEvents);
 ```
 
-- `UniversalEvents` - a universal event emitter. Used internally to emit routing events
+##### Required dependencies
+
+Name | Type | Description
+-|-|-
+`UniversalEventsToken` | `UniversalEvents` | An event emitter plugin to emit stats to, such as the one provided by [`fusion-plugin-universal-events`](https://github.com/fusionjs/fusion-plugin-universal-events).
+
 
 #### `Router`
 


### PR DESCRIPTION
Fixes #74 | Rendered: [link](https://github.com/AlexMSmithCA/fusion-plugin-react-router/blob/f78b3527f7ccc22219e7bcce33c98bab2313aeaa/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation