### PR TITLE
Fix timing.render to emit after timing.end is resolved

### DIFF
--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -164,7 +164,7 @@ if (__BROWSER__) {
 
 function getMockEvents({t, title: expectedTitle, page: expectedPage}) {
   const expected = __NODE__
-    ? ['render:server', 'pageview:server']
+    ? ['pageview:server', 'render:server']
     : ['pageview:browser'];
   return createPlugin({
     provides: () => ({

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -62,8 +62,10 @@ export default createPlugin({
             }
             return payload;
           });
-          ctx.timing.render.then(emitTiming('render:server'));
-          ctx.timing.end.then(emitTiming('pageview:server'));
+          ctx.timing.end.then(timing => {
+            emitTiming('pageview:server')(timing);
+            ctx.timing.render.then(emitTiming('render:server'));
+          });
         });
       } else if (__BROWSER__) {
         // TODO(#3): We should consider adding render/downstream/upstream timings for the browser


### PR DESCRIPTION
Emit `timing.render` only after `timing.end` is resolved, so `ctx.status` is resolved at that point.

fixes #96 