### PR TITLE
Make UniversalEventsToken optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ The plugin.
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 ```
 
-The [universal events](https://github.com/fusionjs/fusion-plugin-universal-events) plugin. Required.
+The [universal events](https://github.com/fusionjs/fusion-plugin-universal-events) plugin. Optional.
+
+Provide the UniversalEventsToken when you would like to emit routing events for data collection.
 
 ---
 

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -181,6 +181,24 @@ test('events with no tracking id and deep path and route prefix', async t => {
   t.end();
 });
 
+test('without UniversalEventsToken', async t => {
+  const Hello = () => <div>Hello</div>;
+  const element = (
+    <div>
+      <Route path="/" trackingId="home" component={Hello} />
+    </div>
+  );
+  const app = getApp(element);
+  app.register(getMockBodySetter());
+  const simulator = setup(app);
+  const ctx = await simulator.render('/');
+  if (__NODE__) {
+    t.ok(ctx.rendered.includes('<div>Hello</div>'), 'matches route');
+  }
+  cleanup();
+  t.end();
+});
+
 if (__BROWSER__) {
   test('mapping events in browser', async t => {
     const Home = withRouter(({location, history}) => {


### PR DESCRIPTION
Rationale: Currently when making a very simple Fusion.js application with only a router, you're also required to pull in the UniversalEventsToken, which also requires FetchToken. It feels quite complex for a small non-Uber application, and making this token optional will do quite a lot to ease the first-time app developer.

Fixes #114