### PR TITLE
Expose history object in plugin API and token for overriding Router provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ import Router from 'fusion-plugin-react-router';
 
 The plugin.
 
+##### `RouterToken`
+
+```jsx
+import {RouterToken} from 'fusion-plugin-react-router';
+```
+
+A token for registering the router plugin on. You only need to register the plugin on this token if another
+plugin depends on receiving the history object.
+
+##### `RouterProviderToken`
+
+```jsx
+import {RouterProviderToken} from 'fusion-plugin-react-router';
+```
+
+An optional dependency of this plugin, used to replace the routing provider. Defaults to `import {Router} from react-router-dom`.
+This is necessary for integrating with `connected-react-router`.
+
 ##### `UniversalEventsToken`
 
 ```jsx
@@ -127,6 +145,7 @@ import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 The [universal events](https://github.com/fusionjs/fusion-plugin-universal-events) plugin. Optional.
 
 Provide the UniversalEventsToken when you would like to emit routing events for data collection.
+
 
 ---
 
@@ -152,6 +171,27 @@ Router will emit the following events/metrics via the [universal events](https:/
   - `title: string` - (1)`props.trackingId` provided by [`<Route>`](#route), or (2)the path of an [exact match](https://reacttraining.com/react-router/web/api/match), or (3)`ctx.path`.
 
 ---
+
+#### Accessing History
+
+This plugin provides an API to access the history object.
+
+```js
+import {createPlugin} from 'fusion-core';
+import RouterPlugin, {RouterToken} from 'fusion-plugin-react-router';
+
+app.register(RouterToken, RouterPlugin);
+app.register(createPlugin({
+  deps: {
+    router: RouterToken,
+  },
+  middleware: ({router}) => (ctx, next) => {
+    const {history} = router.from(ctx);
+    // ...
+    return next();
+  }
+}));
+```
 
 #### Router
 

--- a/src/__tests__/notfound.browser.js
+++ b/src/__tests__/notfound.browser.js
@@ -11,6 +11,7 @@ import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, Route, NotFound} from '../browser';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 test('noops', t => {
   const root = document.createElement('div');
@@ -21,7 +22,7 @@ test('noops', t => {
     </NotFound>
   );
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route component={Hello} />
     </Router>
   );

--- a/src/__tests__/notfound.node.js
+++ b/src/__tests__/notfound.node.js
@@ -10,6 +10,7 @@ import test from 'tape-cup';
 import React from 'react';
 import {renderToString as render} from 'react-dom/server';
 import {Router, Route, NotFound} from '../server';
+import {createServerHistory} from '../modules/ServerHistory';
 
 test('sets code', t => {
   const Hello = () => (
@@ -19,12 +20,16 @@ test('sets code', t => {
   );
   const state = {code: 0};
   const ctx = {
+    action: null,
+    location: null,
+    url: null,
     setCode(code) {
       state.code = code;
     },
   };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/" context={ctx}>
+    <Router history={history} context={ctx}>
       <Route component={Hello} />
     </Router>
   );

--- a/src/__tests__/redirect.browser.js
+++ b/src/__tests__/redirect.browser.js
@@ -11,13 +11,14 @@ import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, Route, Redirect} from '../browser';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 test('test Redirect', t => {
   const root = document.createElement('div');
   const Hello = () => <div>Hello</div>;
   const Moved = () => <Redirect to="/hello">Hi</Redirect>;
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <div>
         <Route path="/" component={Moved} />
         <Route path="/hello" component={Hello} />
@@ -30,7 +31,7 @@ test('test Redirect', t => {
 
   // reset the url back to "/"
   ReactDOM.render(
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Redirect to="/" />
     </Router>,
     document.createElement('div')

--- a/src/__tests__/redirect.node.js
+++ b/src/__tests__/redirect.node.js
@@ -10,6 +10,7 @@ import test from 'tape-cup';
 import React from 'react';
 import {renderToString as render} from 'react-dom/server';
 import {Router, Route, Redirect} from '../server';
+import {createServerHistory} from '../modules/ServerHistory';
 
 test('redirects to a new URL', t => {
   const Hello = () => <div>Hello</div>;
@@ -17,6 +18,9 @@ test('redirects to a new URL', t => {
   let setCode = false;
   let didRedirect = false;
   const state = {
+    action: null,
+    location: null,
+    url: null,
     setCode: code => {
       t.equal(code, 307);
       setCode = true;
@@ -27,8 +31,9 @@ test('redirects to a new URL', t => {
     },
   };
   const ctx = state;
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/" context={ctx}>
+    <Router history={history} context={ctx}>
       <div>
         <Route path="/" component={Moved} />
         <Route path="/hello" component={Hello} />

--- a/src/__tests__/route.browser.js
+++ b/src/__tests__/route.browser.js
@@ -11,12 +11,13 @@ import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, Route} from '../browser';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 test('matches as expected', t => {
   const root = document.createElement('div');
   const Hello = () => <div>Hello</div>;
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route path="/" component={Hello} />
     </Router>
   );
@@ -28,7 +29,7 @@ test('misses as expected', t => {
   const root = document.createElement('div');
   const Hello = () => <div>Hello</div>;
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route exact path="/bar" component={Hello} />
     </Router>
   );
@@ -40,7 +41,7 @@ test('support props.render', t => {
   const root = document.createElement('div');
   const Hello = () => <div>Hello</div>;
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route path="/" render={() => <Hello />} />
     </Router>
   );
@@ -55,7 +56,7 @@ test('support props.children as render prop', t => {
   const Hello = () => <div>Hello</div>;
   /* eslint-disable react/no-children-prop */
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route path="/" children={() => <Hello />} />
     </Router>
   );

--- a/src/__tests__/route.node.js
+++ b/src/__tests__/route.node.js
@@ -10,11 +10,18 @@ import test from 'tape-cup';
 import React from 'react';
 import {renderToString as render} from 'react-dom/server';
 import {Router, Route} from '../server';
+import {createServerHistory} from '../modules/ServerHistory';
 
 test('matches as expected', t => {
   const Hello = () => <div>Hello</div>;
+  const ctx = {
+    action: null,
+    location: null,
+    url: null,
+  };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/">
+    <Router history={history}>
       <Route path="/" component={Hello} />
     </Router>
   );
@@ -23,8 +30,14 @@ test('matches as expected', t => {
 });
 test('misses as expected', t => {
   const Hello = () => <div>Hello</div>;
+  const ctx = {
+    action: null,
+    location: null,
+    url: null,
+  };
+  const history = createServerHistory('/', ctx, '/foo');
   const el = (
-    <Router location="/foo">
+    <Router history={history}>
       <Route path="/bar" component={Hello} />
     </Router>
   );
@@ -32,9 +45,15 @@ test('misses as expected', t => {
   t.end();
 });
 test('support props.render', t => {
+  const ctx = {
+    action: null,
+    location: null,
+    url: null,
+  };
+  const history = createServerHistory('/', ctx, '/');
   const Hello = () => <div>Hello</div>;
   const el = (
-    <Router location="/">
+    <Router history={history}>
       <Route path="/" render={() => <Hello />} />
     </Router>
   );
@@ -46,10 +65,16 @@ test('support props.render', t => {
   t.end();
 });
 test('support props.children as render prop', t => {
+  const ctx = {
+    action: null,
+    location: null,
+    url: null,
+  };
+  const history = createServerHistory('/', ctx, '/');
   const Hello = () => <div>Hello</div>;
   /* eslint-disable react/no-children-prop */
   const el = (
-    <Router location="/">
+    <Router history={history}>
       <Route path="/" children={() => <Hello />} />
     </Router>
   );

--- a/src/__tests__/status.browser.js
+++ b/src/__tests__/status.browser.js
@@ -11,6 +11,7 @@ import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, Route, Status} from '../browser';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 test('noops', t => {
   const root = document.createElement('div');
@@ -20,7 +21,7 @@ test('noops', t => {
     </Status>
   );
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Route component={Hello} />
     </Router>
   );

--- a/src/__tests__/status.node.js
+++ b/src/__tests__/status.node.js
@@ -10,6 +10,7 @@ import test from 'tape-cup';
 import React from 'react';
 import {renderToString as render} from 'react-dom/server';
 import {Router, Route, Status} from '../server';
+import {createServerHistory} from '../modules/ServerHistory';
 
 test('sets code with static code', t => {
   const Hello = () => (
@@ -19,12 +20,16 @@ test('sets code with static code', t => {
   );
   const state = {code: 0};
   const ctx = {
+    action: null,
+    location: null,
+    url: null,
     setCode(code) {
       state.code = code;
     },
   };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/" context={ctx}>
+    <Router history={history} context={ctx}>
       <Route component={Hello} />
     </Router>
   );
@@ -41,12 +46,16 @@ test('sets code with numeric code', t => {
   );
   const state = {code: 0};
   const ctx = {
+    action: null,
+    location: null,
+    url: null,
     setCode(code) {
       state.code = code;
     },
   };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/" context={ctx}>
+    <Router history={history} context={ctx}>
       <Route component={Hello} />
     </Router>
   );
@@ -63,12 +72,16 @@ test('sets code with string code', t => {
   );
   const state = {code: 0};
   const ctx = {
+    action: null,
+    location: null,
+    url: null,
     setCode(code) {
       state.code = code;
     },
   };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/" context={ctx}>
+    <Router history={history} context={ctx}>
       <Route component={Hello} />
     </Router>
   );

--- a/src/__tests__/switch.browser.js
+++ b/src/__tests__/switch.browser.js
@@ -11,13 +11,14 @@ import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, Switch, Route} from '../browser';
+import createBrowserHistory from 'history/createBrowserHistory';
 
 test('matches as expected', t => {
   const root = document.createElement('div');
   const Hello = () => <div>Hello</div>;
   const Hi = () => <div>Hi</div>;
   const el = (
-    <Router>
+    <Router history={createBrowserHistory()}>
       <Switch>
         <Route path="/" component={Hello} />
         <Route path="/" component={Hi} />

--- a/src/__tests__/switch.node.js
+++ b/src/__tests__/switch.node.js
@@ -10,12 +10,19 @@ import test from 'tape-cup';
 import React from 'react';
 import {renderToString as render} from 'react-dom/server';
 import {Router, Switch, Route} from '../server';
+import {createServerHistory} from '../modules/ServerHistory';
 
 test('matches as expected', t => {
   const Hello = () => <div>Hello</div>;
   const Hi = () => <div>Hi</div>;
+  const ctx = {
+    action: null,
+    location: null,
+    url: null,
+  };
+  const history = createServerHistory('/', ctx, '/');
   const el = (
-    <Router location="/">
+    <Router history={history}>
       <Switch>
         <Route path="/" component={Hello} />
         <Route path="/" component={Hi} />

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
  * @flow
  */
 
-import plugin from './plugin';
+import plugin, {RouterProviderToken, RouterToken} from './plugin';
 import * as server from './server';
 import * as browser from './browser';
 
@@ -45,4 +45,6 @@ export {
   Status,
   Switch,
   withRouter,
+  RouterProviderToken,
+  RouterToken,
 };

--- a/src/modules/BrowserRouter.js
+++ b/src/modules/BrowserRouter.js
@@ -9,18 +9,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Router as BaseRouter} from 'react-router-dom';
-import createHistory from 'history/createBrowserHistory';
 
 export {Status, NotFound} from './Status';
 export {Redirect} from './Redirect';
 
 class BrowserRouter extends React.Component<any> {
-  history: any;
   lastTitle: any;
 
   constructor(props: any = {}, context: any) {
     super(props, context);
-    this.history = createHistory(this.props);
     this.lastTitle = null;
   }
 
@@ -37,19 +34,21 @@ class BrowserRouter extends React.Component<any> {
   }
 
   render() {
+    const {Provider, history, basename} = this.props;
     return (
-      <BaseRouter history={this.history}>{this.props.children}</BaseRouter>
+      <Provider basename={basename} history={history}>
+        {this.props.children}
+      </Provider>
     );
   }
 }
 
 BrowserRouter.propTypes = {
-  basename: PropTypes.string,
-  forceRefresh: PropTypes.bool,
-  getUserConfirmation: PropTypes.func,
-  keyLength: PropTypes.number,
   children: PropTypes.node,
   onRoute: PropTypes.func,
+  history: PropTypes.object,
+  Provider: PropTypes.any,
+  basename: PropTypes.string,
 };
 
 BrowserRouter.contextTypes = {
@@ -63,6 +62,7 @@ BrowserRouter.childContextTypes = {
 // $FlowFixMe
 BrowserRouter.defaultProps = {
   onRoute: () => {},
+  Provider: BaseRouter,
 };
 
 export {BrowserRouter as Router};

--- a/src/modules/ServerHistory.js
+++ b/src/modules/ServerHistory.js
@@ -1,0 +1,126 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import {createPath, parsePath} from 'history';
+import type {HistoryType, LocationType} from '../types';
+
+const addLeadingSlash = path => (path.charAt(0) === '/' ? path : '/' + path);
+
+const addRoutePrefix = (
+  location: string | LocationType,
+  prefix: string
+): string | LocationType => {
+  if (!prefix) return location;
+  if (typeof location === 'string') {
+    return `${prefix}${addLeadingSlash(location)}`;
+  } else {
+    return {
+      ...location,
+      pathname: `${prefix}${addLeadingSlash(location.pathname)}`,
+    };
+  }
+};
+
+const removeRoutePrefix = (
+  location: string | LocationType,
+  prefix: string
+): string | LocationType => {
+  if (!prefix) return location;
+  const pathname = typeof location === 'string' ? location : location.pathname;
+  const hasPrefix = (pathname + '/').indexOf(prefix + '/') === 0;
+  const unprefixedPathname = pathname.slice(prefix.length);
+  const relativePathname = hasPrefix ? unprefixedPathname : pathname;
+
+  if (typeof location === 'string') {
+    return relativePathname;
+  } else {
+    return {
+      ...location,
+      pathname: relativePathname,
+    };
+  }
+};
+
+const createLocation = (
+  path: string | LocationType,
+  prefix: string
+): LocationType => {
+  const unprefixedPath = removeRoutePrefix(path, prefix);
+  return parsePath(unprefixedPath);
+};
+
+const createPrefixedURL = (
+  location: string | LocationType,
+  prefix: string
+): string | LocationType => {
+  if (typeof location === 'string') {
+    return addRoutePrefix(location, prefix);
+  } else {
+    return createPath(addRoutePrefix(location, prefix));
+  }
+};
+
+/**
+ * @param {string|object} location
+ * @param {string} prefix
+ * @returns {string}
+ */
+const createURL = (location, prefix) => {
+  if (typeof location === 'string') {
+    return removeRoutePrefix(location, prefix);
+  } else {
+    return createPath(removeRoutePrefix(location, prefix));
+  }
+};
+
+const staticHandler = methodName => () => {
+  throw new Error(`You cannot ${methodName} with server side <Router>`);
+};
+
+const noop = () => {};
+
+type ContextType = {
+  action: ?string,
+  location: any,
+  url: ?string,
+};
+
+export function createServerHistory(
+  basename: string,
+  context: ContextType,
+  location: string | LocationType
+): HistoryType {
+  function createHref(location: string | LocationType): string | LocationType {
+    return createPrefixedURL(location, basename);
+  }
+  function push(path: string) {
+    context.action = 'PUSH';
+    context.location = createLocation(path, basename);
+    // $FlowFixMe
+    context.url = createURL(path, basename);
+  }
+
+  function replace(path: string) {
+    context.action = 'REPLACE';
+    context.location = createLocation(path, basename);
+    // $FlowFixMe
+    context.url = createURL(path, basename);
+  }
+  const history = {
+    length: 0,
+    createHref,
+    action: 'POP',
+    location: createLocation(location, basename),
+    push,
+    replace,
+    go: staticHandler('go'),
+    goBack: staticHandler('back'),
+    goForward: staticHandler('forward'),
+    listen: () => noop,
+  };
+  return history;
+}

--- a/src/modules/ServerRouter.js
+++ b/src/modules/ServerRouter.js
@@ -7,91 +7,7 @@
  */
 
 import React from 'react';
-import {createPath, parsePath} from 'history';
 import {Router} from 'react-router-dom';
-
-const addLeadingSlash = path => (path.charAt(0) === '/' ? path : '/' + path);
-
-/**
- * @param {string|object} location
- * @param {string} prefix
- * @returns {object}
- */
-const addRoutePrefix = (location, prefix) => {
-  if (!prefix) return location;
-  if (typeof location === 'string') {
-    return `${prefix}${addLeadingSlash(location)}`;
-  } else {
-    return {
-      ...location,
-      pathname: `${prefix}${addLeadingSlash(location.pathname)}`,
-    };
-  }
-};
-
-/**
- * @param {string|object} location
- * @param {string} prefix
- * @returns {object}
- */
-const removeRoutePrefix = (location, prefix) => {
-  if (!prefix) return location;
-  const pathname = typeof location === 'string' ? location : location.pathname;
-  const hasPrefix = (pathname + '/').indexOf(prefix + '/') === 0;
-  const unprefixedPathname = pathname.slice(prefix.length);
-  const relativePathname = hasPrefix ? unprefixedPathname : pathname;
-
-  if (typeof location === 'string') {
-    return relativePathname;
-  } else {
-    return {
-      ...location,
-      pathname: relativePathname,
-    };
-  }
-};
-
-/**
- * @param {string} path
- * @param {string} prefix
- * @returns {object}
- */
-const createLocation = (path, prefix) => {
-  const unprefixedPath = removeRoutePrefix(path, prefix);
-  return parsePath(unprefixedPath);
-};
-
-/**
- * @param {string|object} location
- * @param {string} prefix
- * @returns {string}
- */
-const createPrefixedURL = (location, prefix) => {
-  if (typeof location === 'string') {
-    return addRoutePrefix(location, prefix);
-  } else {
-    return createPath(addRoutePrefix(location, prefix));
-  }
-};
-
-/**
- * @param {string|object} location
- * @param {string} prefix
- * @returns {string}
- */
-const createURL = (location, prefix) => {
-  if (typeof location === 'string') {
-    return removeRoutePrefix(location, prefix);
-  } else {
-    return createPath(removeRoutePrefix(location, prefix));
-  }
-};
-
-const staticHandler = methodName => () => {
-  throw new Error(`You cannot ${methodName} with server side <Router>`);
-};
-
-const noop = () => {};
 
 /**
  * The public top-level API for a "static" <Router>, so-called because it
@@ -109,63 +25,21 @@ export class ServerRouter extends React.Component<any> {
     };
   }
 
-  /**
-   * @param {string|object} location
-   * @returns {string}
-   */
-  createHref(location: any) {
-    return createPrefixedURL(location, this.props.basename);
-  }
-
-  /**
-   * @param {string} path
-   */
-  handlePush(path: any) {
-    const {basename, context} = this.props;
-    context.action = 'PUSH';
-    context.location = createLocation(path, basename);
-    context.url = createURL(path, basename);
-  }
-
-  /**
-   * @param {string} path
-   */
-  handleReplace(path: any) {
-    const {basename, context} = this.props;
-    context.action = 'REPLACE';
-    context.location = createLocation(path, basename);
-    context.url = createURL(path, basename);
-  }
-
-  handleListen() {
-    return noop;
-  }
-
   render() {
-    /* eslint-disable no-unused-vars */
-    const {context, location, ...props} = this.props;
-    /* eslint-enable no-unused-vars */
-    const history = {
-      createHref: this.createHref.bind(this),
-      action: 'POP',
-      location: createLocation(location, this.props.basename),
-      push: this.handlePush.bind(this),
-      replace: this.handleReplace.bind(this),
-      go: staticHandler('go'),
-      back: staticHandler('back'),
-      forward: staticHandler('forward'),
-      listen: this.handleListen,
-    };
-
-    return <Router {...props} history={history} />;
+    const {Provider, history, basename, children} = this.props;
+    return (
+      <Provider basename={basename} history={history}>
+        {children}
+      </Provider>
+    );
   }
 }
 
 // $FlowFixMe
 ServerRouter.defaultProps = {
   basename: '',
-  location: '/',
   context: {},
+  Provider: Router,
   onRoute: () => {},
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,8 +6,8 @@
  * @flow
  */
 
+import * as React from 'react';
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
-import React from 'react';
 import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';
 import {Router as ServerRouter} from './server';
 import {Router as BrowserRouter} from './browser';
@@ -15,9 +15,25 @@ import {Router as DefaultProvider} from 'react-router-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
 import {createServerHistory} from './modules/ServerHistory';
 import type {HistoryType} from './types';
+import type {Token, Context} from 'fusion-core';
 
-export const RouterProviderToken = createToken('RouterProvider');
-export const RouterToken = createToken('Router');
+type ProviderPropsType = {
+  history: HistoryType,
+  basename: string,
+};
+type HistoryWrapperType = {
+  from: (
+    ctx: Context
+  ) => {
+    history: HistoryType,
+  },
+};
+
+export const RouterProviderToken: Token<
+  React.ComponentType<ProviderPropsType>
+> = createToken('RouterProvider');
+
+export const RouterToken: Token<HistoryWrapperType> = createToken('Router');
 
 const Router = __NODE__ ? ServerRouter : BrowserRouter;
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,27 +8,40 @@
 
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import React from 'react';
-import {createPlugin, html, unescape} from 'fusion-core';
+import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';
 import {Router as ServerRouter} from './server';
 import {Router as BrowserRouter} from './browser';
+import {Router as DefaultProvider} from 'react-router-dom';
+import createBrowserHistory from 'history/createBrowserHistory';
+import {createServerHistory} from './modules/ServerHistory';
+import type {HistoryType} from './types';
+
+export const RouterProviderToken = createToken('RouterProvider');
+export const RouterToken = createToken('Router');
 
 const Router = __NODE__ ? ServerRouter : BrowserRouter;
+
 export default createPlugin({
   deps: {
     emitter: UniversalEventsToken.optional,
+    Provider: RouterProviderToken.optional,
   },
-  middleware: ({emitter}) => {
+  middleware: ({emitter, Provider = DefaultProvider}, self) => {
     return async (ctx, next) => {
       const prefix = ctx.prefix || '';
       if (!ctx.element) {
         return next();
       }
+      const myAPI = self.from(ctx);
       if (__NODE__) {
         let pageData = {
           title: ctx.path,
           page: ctx.path,
         };
         const context = {
+          action: null,
+          location: null,
+          url: null,
           setCode: code => {
             ctx.status = code;
           },
@@ -36,13 +49,17 @@ export default createPlugin({
             ctx.redirect(url);
           },
         };
+        // Expose the history object
+        const history = createServerHistory(prefix, context, prefix + ctx.url);
+        myAPI.history = history;
         ctx.element = (
           <Router
+            history={history}
+            Provider={Provider}
             onRoute={d => {
               pageData = d;
             }}
             basename={prefix}
-            location={prefix + ctx.url}
             context={context}
           >
             {ctx.element}
@@ -90,8 +107,13 @@ export default createPlugin({
             }
             return payload;
           });
+        // Expose the history object
+        const history = createBrowserHistory({basename: ctx.prefix});
+        myAPI.history = history;
         ctx.element = (
           <Router
+            history={history}
+            Provider={Provider}
             basename={ctx.prefix}
             onRoute={payload => {
               pageData = payload;
@@ -103,6 +125,16 @@ export default createPlugin({
         );
         return next();
       }
+    };
+  },
+  provides() {
+    return {
+      from: memoize(() => {
+        const api: {history: HistoryType} = ({
+          history: null,
+        }: any);
+        return api;
+      }),
     };
   },
 });

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,31 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type LocationType = {
+  pathname: string,
+  search: string,
+  hash: string,
+  state?: Object,
+  key?: string,
+};
+
+type NavigationFunctionType = (
+  path: string,
+  state?: Object
+) => void | (LocationType => void);
+
+export type HistoryType = {
+  length: number,
+  location: LocationType,
+  action: string,
+  push: NavigationFunctionType,
+  replace: NavigationFunctionType,
+  go: (n: number) => void,
+  goBack: () => void,
+  goForward: () => void,
+};


### PR DESCRIPTION
In order to support router integrations such as [connected-react-router](https://github.com/supasate/connected-react-router) we need to expose the history object and a way to replace the default Router provider component. This PR introduces the following tokens:

```js
import {RouterToken, RouterProviderToken} from 'fusion-plugin-react-router'
```

And updates plugin to provide:

```js
app.middleware({router: RouterToken}, ({router}) => (ctx, next) => {
  const {history} = router.from(ctx);
  // ...
  return next();
});
```

This also fixes a bug where the server history API did not match the browser history API.
