### PR TITLE
Use scoped emitter for server side events

### DIFF
--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -384,19 +384,25 @@ function getMockEvents({t, title: expectedTitle, page: expectedPage}) {
       map(mapper) {
         t.equal(typeof mapper, 'function');
       },
-      emit(type, {title, page, status, timing}) {
+      emit(type, {title, page}) {
+        if (__NODE__) {
+          throw new Error('fail');
+        }
         t.equal(type, expected.shift(), 'emits with the correct type');
         t.equal(title, expectedTitle, 'correct title');
         t.equal(page, expectedPage, 'correct page');
-        if (__NODE__) {
-          t.equal(status, 200, 'emits status code');
-          t.equal(typeof timing, 'number', 'emits with the correct value');
-        }
       },
-      from() {
+      from(ctx) {
+        t.ok(ctx, 'emits from scoped emitter');
         return {
           map() {},
-          emit() {},
+          emit(type, {title, page, status, timing}) {
+            t.equal(type, expected.shift(), 'emits with the correct type');
+            t.equal(title, expectedTitle, 'correct title');
+            t.equal(page, expectedPage, 'correct page');
+            t.equal(status, 200, 'emits status code');
+            t.equal(typeof timing, 'number', 'emits with the correct value');
+          },
         };
       },
     }),

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -89,15 +89,16 @@ export default createPlugin({
           );
 
           if (emitter) {
+            const scopedEmitter = emitter.from(ctx);
             const emitTiming = type => timing => {
-              emitter.emit(type, {
+              scopedEmitter.emit(type, {
                 title: pageData.title,
                 page: pageData.page,
                 status: ctx.status,
                 timing,
               });
             };
-            emitter.from(ctx).map(payload => {
+            scopedEmitter.map(payload => {
               if (payload && typeof payload === 'object') {
                 payload.__url__ = pageData.title;
               }


### PR DESCRIPTION
Fixes #179 

Updates server side plugin to use the ctx scoped emitter when emitting pageview stats. This allows listeners to the event to have access to ctx.
