### PR TITLE
Add url params to client event metadata

### DIFF
--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -360,6 +360,7 @@ if (__BROWSER__) {
           t.deepLooseEqual(payload, expected);
           const mapped = mapper({});
           t.equal(mapped.__url__, expected.title);
+          t.deepEqual(mapped.__urlParams__, expected.params);
           if (expectedPayloads.length === 0) {
             cleanup();
             t.end();

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -121,6 +121,7 @@ export default createPlugin({
           emitter.map(payload => {
             if (payload && typeof payload === 'object') {
               payload.__url__ = pageData.title;
+              payload.__urlParams__ = pageData.params;
             }
             return payload;
           });


### PR DESCRIPTION
This will provide our logs with a lot of page information for free.

For example the route "/:languageCountryPair/:citySlug/food-delivery/:storeSlug/:encodedStoreUuid/" isn't very useful in the logs.

But if we enable users to filter by citySlug, storeSlug, languageCountryPair it becomes much more useful.