### PR TITLE
Improve static types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,7 +6,6 @@
 ./src/
 
 [libs]
-./node_modules/fusion-core/flow-typed
 
 [lints]
 

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -8,3 +8,4 @@
 
 declare var __NODE__: boolean;
 declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,0 +1,11 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __IS_PREPARE__: boolean;

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -8,4 +8,3 @@
 
 declare var __NODE__: boolean;
 declare var __BROWSER__: boolean;
-declare var __IS_PREPARE__: boolean;

--- a/flow-typed/npm/history_v4.x.x.js
+++ b/flow-typed/npm/history_v4.x.x.js
@@ -1,0 +1,155 @@
+// @flow
+// flow-typed signature: 540e42745f797051f3bf17a6af1ccf06
+// flow-typed version: 6a3fe49a8b/history_v4.x.x/flow_>=v0.25.x
+
+declare module 'history' {
+  declare type LocationType = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: Object,
+    key?: string,
+  };
+
+  declare function parsePath(path: string | LocationType): LocationType;
+
+  declare function createPath(
+    path: string | LocationType
+  ): string | LocationType;
+}
+
+declare module 'history/createBrowserHistory' {
+  declare function Unblock(): void;
+
+  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
+
+  declare export type BrowserLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+    // Browser and Memory specific
+    state?: {},
+    key?: string,
+  };
+
+  declare interface IBrowserHistory {
+    length: number;
+    location: BrowserLocation;
+    action: Action;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<BrowserLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(path: $Shape<BrowserLocation>, state?: {}): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    listen: any;
+    block(
+      callback: (location: BrowserLocation, action: Action) => boolean
+    ): void;
+  }
+
+  declare export type BrowserHistory = IBrowserHistory;
+
+  declare type HistoryOpts = {
+    basename?: string,
+    forceRefresh?: boolean,
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void
+    ) => void,
+  };
+
+  declare export default (opts?: HistoryOpts) => BrowserHistory;
+}
+
+declare module 'history/createMemoryHistory' {
+  declare function Unblock(): void;
+
+  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
+
+  declare export type MemoryLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+    // Browser and Memory specific
+    state: {},
+    key: string,
+  };
+
+  declare interface IMemoryHistory {
+    length: number;
+    location: MemoryLocation;
+    action: Action;
+    index: number;
+    entries: Array<string>;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<MemoryLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(location: $Shape<MemoryLocation>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    // Memory only
+    canGo(n: number): boolean;
+    listen: Function;
+    block(message: string): typeof Unblock;
+    block((location: MemoryLocation, action: Action) => string): typeof Unblock;
+  }
+
+  declare export type MemoryHistory = IMemoryHistory;
+
+  declare type HistoryOpts = {
+    initialEntries?: Array<string>,
+    initialIndex?: number,
+    keyLength?: number,
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void
+    ) => void,
+  };
+
+  declare export default (opts?: HistoryOpts) => MemoryHistory;
+}
+
+declare module 'history/createHashHistory' {
+  declare function Unblock(): void;
+
+  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
+
+  declare export type HashLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+  };
+
+  declare interface IHashHistory {
+    length: number;
+    location: HashLocation;
+    action: Action;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<HashLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(location: $Shape<HashLocation>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    listen: Function;
+    block(message: string): typeof Unblock;
+    block((location: HashLocation, action: Action) => string): typeof Unblock;
+    push(path: string): void;
+  }
+
+  declare export type HashHistory = IHashHistory;
+
+  declare type HistoryOpts = {
+    basename?: string,
+    hashType: 'slash' | 'noslash' | 'hashbang',
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void
+    ) => void,
+  };
+
+  declare export default (opts?: HistoryOpts) => HashHistory;
+}

--- a/flow-typed/npm/prop-types_v15.x.x.js
+++ b/flow-typed/npm/prop-types_v15.x.x.js
@@ -1,0 +1,37 @@
+// @flow
+// flow-typed signature: d9a983bb1ac458a256c31c139047bdbb
+// flow-typed version: 927687984d/prop-types_v15.x.x/flow_>=v0.41.x
+
+type $npm$propTypes$ReactPropsCheckType = (
+  props: any,
+  propName: string,
+  componentName: string,
+  href?: string
+) => ?Error;
+
+declare module 'prop-types' {
+  declare var array: React$PropType$Primitive<Array<any>>;
+  declare var bool: React$PropType$Primitive<boolean>;
+  declare var func: React$PropType$Primitive<Function>;
+  declare var number: React$PropType$Primitive<number>;
+  declare var object: React$PropType$Primitive<Object>;
+  declare var string: React$PropType$Primitive<string>;
+  declare var symbol: React$PropType$Primitive<Symbol>;
+  declare var any: React$PropType$Primitive<any>;
+  declare var arrayOf: React$PropType$ArrayOf;
+  declare var element: React$PropType$Primitive<any>; /* TODO */
+  declare var instanceOf: React$PropType$InstanceOf;
+  declare var node: React$PropType$Primitive<any>; /* TODO */
+  declare var objectOf: React$PropType$ObjectOf;
+  declare var oneOf: React$PropType$OneOf;
+  declare var oneOfType: React$PropType$OneOfType;
+  declare var shape: React$PropType$Shape;
+
+  declare function checkPropTypes<V>(
+    propTypes: $Subtype<{[_: $Keys<V>]: $npm$propTypes$ReactPropsCheckType}>,
+    values: V,
+    location: string,
+    componentName: string,
+    getStack: ?() => ?string
+  ): void;
+}

--- a/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,0 +1,207 @@
+// @flow
+// flow-typed signature: e536f4b8192631923c57c19f39ba2b84
+// flow-typed version: 631e6dae97/react-router-dom_v4.x.x/flow_>=v0.63.x
+
+declare module 'react-router-dom' {
+  import type {ComponentType, ElementConfig, Node, Component} from 'react';
+
+  declare export var BrowserRouter: Class<
+    Component<{|
+      basename?: string,
+      forceRefresh?: boolean,
+      getUserConfirmation?: GetUserConfirmation,
+      keyLength?: number,
+      children?: Node,
+    |}>
+  >;
+
+  declare export var HashRouter: Class<
+    Component<{|
+      basename?: string,
+      getUserConfirmation?: GetUserConfirmation,
+      hashType?: 'slash' | 'noslash' | 'hashbang',
+      children?: Node,
+    |}>
+  >;
+
+  declare export var Link: Class<
+    Component<{
+      className?: string,
+      to: string | LocationShape,
+      replace?: boolean,
+      children?: Node,
+    }>
+  >;
+
+  declare export var NavLink: Class<
+    Component<{
+      to?: string | LocationShape,
+      activeClassName?: string,
+      className?: string,
+      activeStyle?: Object,
+      style?: Object,
+      isActive?: (match: Match, location: Location) => boolean,
+      children?: Node,
+      exact?: boolean,
+      strict?: boolean,
+    }>
+  >;
+
+  // NOTE: Below are duplicated from react-router. If updating these, please
+  // update the react-router and react-router-native types as well.
+  declare export type Location = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: any,
+    key?: string,
+  };
+
+  declare export type LocationShape = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+    state?: any,
+  };
+
+  declare export type HistoryAction = 'PUSH' | 'REPLACE' | 'POP';
+
+  declare export type RouterHistory = {
+    length: number,
+    location: Location,
+    action: HistoryAction,
+    listen(
+      callback: (location: Location, action: HistoryAction) => void
+    ): () => void,
+    push(path: string | LocationShape, state?: any): void,
+    replace(path: string | LocationShape, state?: any): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    canGo?: (n: number) => boolean,
+    block(
+      callback: (location: Location, action: HistoryAction) => boolean
+    ): void,
+    // createMemoryHistory
+    index?: number,
+    entries?: Array<Location>,
+  };
+
+  declare export type Match = {
+    params: {[key: string]: ?string},
+    isExact: boolean,
+    path: string,
+    url: string,
+  };
+
+  declare export type ContextRouter = {|
+    history: RouterHistory,
+    location: Location,
+    match: Match,
+    staticContext?: StaticRouterContext,
+  |};
+
+  declare type ContextRouterVoid = {
+    history: RouterHistory | void,
+    location: Location | void,
+    match: Match | void,
+    staticContext?: StaticRouterContext | void,
+  };
+
+  declare export type GetUserConfirmation = (
+    message: string,
+    callback: (confirmed: boolean) => void
+  ) => void;
+
+  declare export type StaticRouterContext = {
+    url?: string,
+  };
+
+  declare export var StaticRouter: Class<
+    Component<{|
+      basename?: string,
+      location?: string | Location,
+      context: StaticRouterContext,
+      children?: Node,
+    |}>
+  >;
+
+  declare export var MemoryRouter: Class<
+    Component<{|
+      initialEntries?: Array<LocationShape | string>,
+      initialIndex?: number,
+      getUserConfirmation?: GetUserConfirmation,
+      keyLength?: number,
+      children?: Node,
+    |}>
+  >;
+
+  declare export var Router: Class<
+    Component<{
+      history: RouterHistory,
+      basename?: string,
+      children?: Node,
+    }>
+  >;
+
+  declare export var Prompt: Class<
+    Component<{|
+      message: string | ((location: Location) => string | boolean),
+      when?: boolean,
+    |}>
+  >;
+
+  declare export var Redirect: Class<
+    Component<{|
+      to: string | LocationShape,
+      push?: boolean,
+      from?: string,
+      exact?: boolean,
+      strict?: boolean,
+    |}>
+  >;
+
+  declare export var Route: Class<
+    Component<{|
+      component?: ComponentType<*>,
+      render?: (router: ContextRouter) => Node,
+      children?: ComponentType<ContextRouter> | Node,
+      path?: string | Array<string>,
+      exact?: boolean,
+      strict?: boolean,
+      location?: LocationShape,
+      sensitive?: boolean,
+    |}>
+  >;
+
+  declare export var Switch: Class<
+    Component<{|
+      children?: Node,
+      location?: Location,
+    |}>
+  >;
+
+  declare export function withRouter<WrappedComponent: ComponentType<*>>(
+    Component: WrappedComponent
+  ): ComponentType<
+    $Diff<ElementConfig<$Supertype<WrappedComponent>>, ContextRouterVoid>
+  >;
+
+  declare type MatchPathOptions = {
+    path?: string,
+    exact?: boolean,
+    sensitive?: boolean,
+    strict?: boolean,
+  };
+
+  declare export function matchPath(
+    pathname: string,
+    options?: MatchPathOptions | string,
+    parent?: Match
+  ): null | Match;
+
+  declare export function generatePath(
+    pattern?: string,
+    params?: Object
+  ): string;
+}

--- a/flow-typed/tape-cup_v4.x.x.js
+++ b/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,132 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable  */
+
+declare type tape$TestOpts =
+  | {
+      skip: boolean,
+      timeout?: number,
+    }
+  | {
+      skip?: boolean,
+      timeout: number,
+    };
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (
+  a: string | tape$TestOpts | tape$TestCb,
+  b?: tape$TestOpts | tape$TestCb,
+  c?: tape$TestCb
+) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void;
+  pass(msg?: string): void;
+
+  error(err: mixed, msg?: string): void;
+  ifError(err: mixed, msg?: string): void;
+  ifErr(err: mixed, msg?: string): void;
+  iferror(err: mixed, msg?: string): void;
+
+  ok(value: mixed, msg?: string): void;
+  true(value: mixed, msg?: string): void;
+  assert(value: mixed, msg?: string): void;
+
+  notOk(value: mixed, msg?: string): void;
+  false(value: mixed, msg?: string): void;
+  notok(value: mixed, msg?: string): void;
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void;
+  equals(actual: mixed, expected: mixed, msg?: string): void;
+  isEqual(actual: mixed, expected: mixed, msg?: string): void;
+  is(actual: mixed, expected: mixed, msg?: string): void;
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquals(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNot(actual: mixed, expected: mixed, msg?: string): void;
+  not(actual: mixed, expected: mixed, msg?: string): void;
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  same(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  notSame(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  throws(fn: Function, msg?: string): void;
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  doesNotThrow(fn: Function, msg?: string): void;
+
+  timeoutAfter(ms: number): void;
+
+  skip(msg?: string): void;
+  plan(n: number): void;
+  onFinish(fn: Function): void;
+  end(): void;
+  comment(msg: string): void;
+  test: tape$TestFn;
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type tape$TestCb = tape$TestCb;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+
+  declare type Tape = {
+    (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/flow-typed/tape-cup_v4.x.x.js
+++ b/flow-typed/tape-cup_v4.x.x.js
@@ -8,103 +8,102 @@
 
 /* eslint-disable  */
 
-declare type tape$TestOpts =
-  | {
-      skip: boolean,
-      timeout?: number,
-    }
-  | {
-      skip?: boolean,
-      timeout: number,
-    };
-
-declare type tape$TestCb = (t: tape$Context) => mixed;
-declare type tape$TestFn = (
-  a: string | tape$TestOpts | tape$TestCb,
-  b?: tape$TestOpts | tape$TestCb,
-  c?: tape$TestCb
-) => void;
-
-declare interface tape$Context {
-  fail(msg?: string): void;
-  pass(msg?: string): void;
-
-  error(err: mixed, msg?: string): void;
-  ifError(err: mixed, msg?: string): void;
-  ifErr(err: mixed, msg?: string): void;
-  iferror(err: mixed, msg?: string): void;
-
-  ok(value: mixed, msg?: string): void;
-  true(value: mixed, msg?: string): void;
-  assert(value: mixed, msg?: string): void;
-
-  notOk(value: mixed, msg?: string): void;
-  false(value: mixed, msg?: string): void;
-  notok(value: mixed, msg?: string): void;
-
-  // equal + aliases
-  equal(actual: mixed, expected: mixed, msg?: string): void;
-  equals(actual: mixed, expected: mixed, msg?: string): void;
-  isEqual(actual: mixed, expected: mixed, msg?: string): void;
-  is(actual: mixed, expected: mixed, msg?: string): void;
-  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
-  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
-
-  // notEqual + aliases
-  notEqual(actual: mixed, expected: mixed, msg?: string): void;
-  notEquals(actual: mixed, expected: mixed, msg?: string): void;
-  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
-  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
-  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
-  isNot(actual: mixed, expected: mixed, msg?: string): void;
-  not(actual: mixed, expected: mixed, msg?: string): void;
-  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
-  isInequal(actual: mixed, expected: mixed, msg?: string): void;
-
-  // deepEqual + aliases
-  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
-  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
-  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
-  same(actual: mixed, expected: mixed, msg?: string): void;
-
-  // notDeepEqual
-  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
-  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
-  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
-  notSame(actual: mixed, expected: mixed, msg?: string): void;
-  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
-  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
-  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
-  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
-
-  // deepLooseEqual
-  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
-  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
-  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
-
-  // notDeepLooseEqual
-  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
-  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
-  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
-
-  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
-  throws(fn: Function, msg?: string): void;
-  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
-  doesNotThrow(fn: Function, msg?: string): void;
-
-  timeoutAfter(ms: number): void;
-
-  skip(msg?: string): void;
-  plan(n: number): void;
-  onFinish(fn: Function): void;
-  end(): void;
-  comment(msg: string): void;
-  test: tape$TestFn;
-}
-
 declare module 'tape-cup' {
+  declare type tape$TestOpts =
+    | {
+        skip: boolean,
+        timeout?: number,
+      }
+    | {
+        skip?: boolean,
+        timeout: number,
+      };
+
+  declare type tape$TestCb = (t: tape$Context) => mixed;
+  declare type tape$TestFn = (
+    a: string | tape$TestOpts | tape$TestCb,
+    b?: tape$TestOpts | tape$TestCb,
+    c?: tape$TestCb
+  ) => void;
+
+  declare interface tape$Context {
+    fail(msg?: string): void;
+    pass(msg?: string): void;
+
+    error(err: mixed, msg?: string): void;
+    ifError(err: mixed, msg?: string): void;
+    ifErr(err: mixed, msg?: string): void;
+    iferror(err: mixed, msg?: string): void;
+
+    ok(value: mixed, msg?: string): void;
+    true(value: mixed, msg?: string): void;
+    assert(value: mixed, msg?: string): void;
+
+    notOk(value: mixed, msg?: string): void;
+    false(value: mixed, msg?: string): void;
+    notok(value: mixed, msg?: string): void;
+
+    // equal + aliases
+    equal(actual: mixed, expected: mixed, msg?: string): void;
+    equals(actual: mixed, expected: mixed, msg?: string): void;
+    isEqual(actual: mixed, expected: mixed, msg?: string): void;
+    is(actual: mixed, expected: mixed, msg?: string): void;
+    strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+    strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+    // notEqual + aliases
+    notEqual(actual: mixed, expected: mixed, msg?: string): void;
+    notEquals(actual: mixed, expected: mixed, msg?: string): void;
+    notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+    notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+    isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+    isNot(actual: mixed, expected: mixed, msg?: string): void;
+    not(actual: mixed, expected: mixed, msg?: string): void;
+    doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+    isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+    // deepEqual + aliases
+    deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+    deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+    isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+    same(actual: mixed, expected: mixed, msg?: string): void;
+
+    // notDeepEqual
+    notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+    notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+    notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+    notSame(actual: mixed, expected: mixed, msg?: string): void;
+    isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+    isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+    isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+    isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+    // deepLooseEqual
+    deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+    looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+    looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+    // notDeepLooseEqual
+    notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+    notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+    notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+    throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+    throws(fn: Function, msg?: string): void;
+    doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+    doesNotThrow(fn: Function, msg?: string): void;
+
+    timeoutAfter(ms: number): void;
+
+    skip(msg?: string): void;
+    plan(n: number): void;
+    onFinish(fn: Function): void;
+    end(): void;
+    comment(msg: string): void;
+    test: tape$TestFn;
+  }
+  
   declare type TestHarness = Tape;
-  declare type tape$TestCb = tape$TestCb;
   declare type StreamOpts = {
     objectMode?: boolean,
   };

--- a/src/__tests__/notfound.browser.js
+++ b/src/__tests__/notfound.browser.js
@@ -10,8 +10,10 @@
 import test from 'tape-cup';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, Route, NotFound} from '../browser';
+
 import createBrowserHistory from 'history/createBrowserHistory';
+
+import {Router, Route, NotFound} from '../browser.js';
 
 test('noops', t => {
   const root = document.createElement('div');

--- a/src/__tests__/notfound.node.js
+++ b/src/__tests__/notfound.node.js
@@ -8,9 +8,11 @@
 
 import test from 'tape-cup';
 import React from 'react';
+
 import {renderToString as render} from 'react-dom/server';
-import {Router, Route, NotFound} from '../server';
-import {createServerHistory} from '../modules/ServerHistory';
+
+import {Router, Route, NotFound} from '../server.js';
+import {createServerHistory} from '../modules/ServerHistory.js';
 
 test('sets code', t => {
   const Hello = () => (
@@ -23,7 +25,7 @@ test('sets code', t => {
     action: null,
     location: null,
     url: null,
-    setCode(code) {
+    setCode(code: number) {
       state.code = code;
     },
   };

--- a/src/browser.js
+++ b/src/browser.js
@@ -7,22 +7,51 @@
  */
 
 import {
-  BrowserRouter,
-  HashRouter,
-  Link,
-  MemoryRouter,
-  NavLink,
-  Prompt,
-  StaticRouter,
-  Switch,
-  matchPath,
-  withRouter,
+  BrowserRouter as BrowserRouterUntyped,
+  HashRouter as HashRouterUntyped,
+  Link as LinkUntyped,
+  MemoryRouter as MemoryRouterUntyped,
+  NavLink as NavLinkUntyped,
+  Prompt as PromptUntyped,
+  StaticRouter as StaticRouterUntyped,
+  Switch as SwitchUntyped,
+  matchPath as matchPathUntyped,
+  withRouter as withRouterUntyped,
 } from 'react-router-dom';
 
 import {Status, NotFound} from './modules/Status';
 import {Redirect} from './modules/Redirect';
 import {Router} from './modules/BrowserRouter';
 import {Route} from './modules/Route';
+
+import type {
+  BrowserRouterType,
+  HashRouterType,
+  LinkType,
+  MemoryRouterType,
+  NavLinkType,
+  PromptType,
+  StaticRouterType,
+  SwitchType,
+  matchPathType,
+  withRouterType,
+} from './types.js';
+
+/**
+ * Cast each of these imports from react-router-dom to a copied-version of their
+ * types.  This is necessary as the libdef defined types will not be accessible to
+ * consumers of this package.
+ */
+const BrowserRouter: BrowserRouterType = BrowserRouterUntyped;
+const HashRouter: HashRouterType = HashRouterUntyped;
+const Link: LinkType = LinkUntyped;
+const MemoryRouter: MemoryRouterType = MemoryRouterUntyped;
+const NavLink: NavLinkType = NavLinkUntyped;
+const Prompt: PromptType = PromptUntyped;
+const StaticRouter: StaticRouterType = StaticRouterUntyped;
+const Switch: SwitchType = SwitchUntyped;
+const matchPath: matchPathType = matchPathUntyped;
+const withRouter: withRouterType = withRouterUntyped;
 
 export {
   BrowserRouter,

--- a/src/index.js
+++ b/src/index.js
@@ -48,3 +48,5 @@ export {
   RouterProviderToken,
   RouterToken,
 };
+
+export * from './types.js';

--- a/src/modules/BrowserRouter.js
+++ b/src/modules/BrowserRouter.js
@@ -6,22 +6,38 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import {Router as BaseRouter} from 'react-router-dom';
+import {Router as BaseRouterUntyped} from 'react-router-dom';
 
-export {Status, NotFound} from './Status';
-export {Redirect} from './Redirect';
+import type {RouterType, RouterHistoryType} from '../types.js';
 
-class BrowserRouter extends React.Component<any> {
-  lastTitle: any;
+export {Status, NotFound} from './Status.js';
+export {Redirect} from './Redirect.js';
+
+const BaseRouter: RouterType = (BaseRouterUntyped: any);
+
+type PropsType = {|
+  context?: any,
+  onRoute?: Function,
+  history: RouterHistoryType,
+  Provider?: RouterType,
+  basename?: string,
+  children?: React.Node,
+|};
+type ContextType = {
+  __IS_PREPARE__: boolean,
+};
+class BrowserRouter extends React.Component<PropsType> {
+  lastTitle: ?string;
+  context: ContextType;
 
   static defaultProps = {
     onRoute: () => {},
     Provider: BaseRouter,
   };
 
-  constructor(props: any = {}, context: any) {
+  constructor(props: PropsType, context: ContextType) {
     super(props, context);
     this.lastTitle = null;
   }
@@ -32,7 +48,7 @@ class BrowserRouter extends React.Component<any> {
       onRoute: (routeData: any) => {
         if (routeData.title !== this.lastTitle && !__IS_PREPARE__) {
           this.lastTitle = routeData.title;
-          this.props.onRoute(routeData);
+          this.props.onRoute && this.props.onRoute(routeData);
         }
       },
     };
@@ -40,6 +56,7 @@ class BrowserRouter extends React.Component<any> {
 
   render() {
     const {Provider, history, basename} = this.props;
+    if (!Provider) throw new Error('Missing Provider for Browser Router');
     return (
       <Provider basename={basename} history={history}>
         {this.props.children}
@@ -64,4 +81,5 @@ BrowserRouter.childContextTypes = {
   onRoute: PropTypes.func.isRequired,
 };
 
-export {BrowserRouter as Router};
+const BrowserRouterTyped: React.ComponentType<PropsType> = BrowserRouter;
+export {BrowserRouterTyped as Router};

--- a/src/modules/Redirect.js
+++ b/src/modules/Redirect.js
@@ -6,11 +6,36 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
-export class Redirect extends React.Component<any> {
-  constructor(props: any, context: any) {
+import type {LocationShapeType, RedirectType} from '../types.js';
+
+type PropsType = {|
+  to: string | LocationShapeType,
+  push?: boolean,
+  from?: string,
+  exact?: boolean,
+  strict?: boolean,
+  code?: number | string,
+  children?: React.Node,
+|};
+type ContextType = {
+  router: {
+    history: {
+      push: (el: string | LocationShapeType) => void,
+      replace: (el: string | LocationShapeType) => void,
+    },
+    staticContext?: {
+      setCode: (code: number) => void,
+      redirect: (el: string | LocationShapeType) => void,
+    },
+  },
+};
+export class Redirect extends React.Component<PropsType> {
+  context: ContextType;
+
+  constructor(props: PropsType, context: ContextType) {
     super(props, context);
     if (this.isStatic(context)) this.perform();
   }
@@ -24,8 +49,8 @@ export class Redirect extends React.Component<any> {
     if (!this.isStatic()) this.perform();
   }
 
-  isStatic(context: any = this.context) {
-    return context.router && context.router.staticContext;
+  isStatic(context: ContextType = this.context): boolean {
+    return !!(context && context.router && context.router.staticContext);
   }
 
   perform() {
@@ -59,3 +84,6 @@ Redirect.contextTypes = {
     staticContext: PropTypes.object,
   }).isRequired,
 };
+
+// Sanity type checking
+(Redirect: RedirectType);

--- a/src/modules/Route.js
+++ b/src/modules/Route.js
@@ -6,20 +6,40 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import {Route as ReactRouterRoute} from 'react-router-dom';
+import {Route as ReactRouterRouteUntyped} from 'react-router-dom';
 
-const isEmptyChildren = children => React.Children.count(children) === 0;
+import type {RouteType} from '../types.js';
 
-function Route(props: any, context: any) {
+const ReactRouterRoute: RouteType = ReactRouterRouteUntyped;
+
+const isEmptyChildren = (children: React.Node) =>
+  React.Children.count(children) === 0;
+
+type PropsType = {
+  trackingId?: any,
+  component?: React.ComponentType<*>,
+  render?: (...props: any) => React.Node,
+  children?: ((routeProps: {match: MatchType}) => React.Node) | React.Node,
+};
+type ContextType = {
+  onRoute: any,
+};
+type MatchType = {
+  isExact: boolean,
+  path: string,
+  params: Object,
+  url: string,
+};
+function Route(props: PropsType, context: ContextType) {
   const {trackingId, component, render, children, ...remainingProps} = props;
 
   return (
     <ReactRouterRoute
       {...remainingProps}
       // eslint-disable-next-line react/no-children-prop
-      children={routeProps => {
+      children={(routeProps: {match: MatchType}) => {
         const {match} = routeProps;
         if (match && match.isExact) {
           context.onRoute({

--- a/src/modules/ServerHistory.js
+++ b/src/modules/ServerHistory.js
@@ -5,9 +5,11 @@
  *
  * @flow
  */
+
 import {createPath, parsePath} from 'history';
-import type {HistoryType, LocationType} from '../types';
-import {addRoutePrefix, removeRoutePrefix} from './utils';
+
+import {addRoutePrefix, removeRoutePrefix} from './utils.js';
+import type {RouterHistoryType, LocationType} from '../types.js';
 
 const createLocation = (
   path: string | LocationType,
@@ -28,12 +30,10 @@ const createPrefixedURL = (
   }
 };
 
-/**
- * @param {string|object} location
- * @param {string} prefix
- * @returns {string}
- */
-const createURL = (location, prefix) => {
+const createURL = (
+  location: string | LocationType,
+  prefix: string
+): string | LocationType => {
   if (typeof location === 'string') {
     return removeRoutePrefix(location, prefix);
   } else {
@@ -57,7 +57,7 @@ export function createServerHistory(
   basename: string,
   context: ContextType,
   location: string | LocationType
-): HistoryType {
+): RouterHistoryType {
   function createHref(location: string | LocationType): string | LocationType {
     return createPrefixedURL(location, basename);
   }
@@ -90,5 +90,5 @@ export function createServerHistory(
     goForward: staticHandler('forward'),
     listen: () => noop,
   };
-  return history;
+  return (history: any);
 }

--- a/src/modules/ServerRouter.js
+++ b/src/modules/ServerRouter.js
@@ -6,8 +6,22 @@
  * @flow
  */
 
-import React from 'react';
-import {Router} from 'react-router-dom';
+import * as React from 'react';
+
+import {Router as RouterUntyped} from 'react-router-dom';
+
+import type {RouterType, RouterHistoryType} from '../types.js';
+
+const BaseRouter: RouterType = (RouterUntyped: any);
+
+type PropsType = {
+  context?: any,
+  onRoute?: Function,
+  history: RouterHistoryType,
+  Provider?: RouterType,
+  basename?: string,
+  children?: React.Node,
+};
 
 /**
  * The public top-level API for a "static" <Router>, so-called because it
@@ -15,11 +29,11 @@ import {Router} from 'react-router-dom';
  * location changes in a context object. Useful mainly in testing and
  * server-rendering scenarios.
  */
-export class ServerRouter extends React.Component<any> {
+class ServerRouter extends React.Component<PropsType> {
   static defaultProps = {
     basename: '',
     context: {},
-    Provider: Router,
+    Provider: BaseRouter,
     onRoute: () => {},
   };
 
@@ -28,12 +42,14 @@ export class ServerRouter extends React.Component<any> {
       router: {
         staticContext: this.props.context || {},
       },
-      onRoute: (routeData: any) => this.props.onRoute(routeData),
+      onRoute: (routeData: any) =>
+        this.props.onRoute && this.props.onRoute(routeData),
     };
   }
 
   render() {
     const {Provider, history, basename, children} = this.props;
+    if (!Provider) throw new Error('Missing Provider for Server Router');
     return (
       <Provider basename={basename} history={history}>
         {children}
@@ -46,3 +62,6 @@ ServerRouter.childContextTypes = {
   router: () => {},
   onRoute: () => {},
 };
+
+const ServerRouterTyped: React.ComponentType<PropsType> = ServerRouter;
+export {ServerRouterTyped as ServerRouter};

--- a/src/modules/Status.js
+++ b/src/modules/Status.js
@@ -6,11 +6,22 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
-export class Status extends React.Component<any> {
-  constructor(props: any, context: any) {
+type StatusPropsType = {
+  children: React.Node,
+  code?: string | number,
+};
+type StatusContextType = {
+  router: {
+    staticContext: {
+      setCode: (code: number) => void,
+    },
+  },
+};
+export class Status extends React.Component<StatusPropsType> {
+  constructor(props: StatusPropsType, context: StatusContextType) {
     super(props, context);
     const {
       router: {staticContext},
@@ -32,6 +43,6 @@ Status.contextTypes = {
   }),
 };
 
-export const NotFound = (props: any) => (
+export const NotFound = <TProps: {children: React.Node}>(props: TProps) => (
   <Status code={404}>{props.children}</Status>
 );

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,27 +7,30 @@
  */
 
 import * as React from 'react';
-import {UniversalEventsToken} from 'fusion-plugin-universal-events';
-import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';
-import {Router as ServerRouter} from './server';
-import {Router as BrowserRouter} from './browser';
 import {Router as DefaultProvider} from 'react-router-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
-import {createServerHistory} from './modules/ServerHistory';
-import type {HistoryType} from './types';
+
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
+import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';
 import type {Token, Context, FusionPlugin} from 'fusion-core';
-import {addRoutePrefix} from './modules/utils';
+
+import {Router as ServerRouter} from './server.js';
+import {Router as BrowserRouter} from './browser.js';
+import {createServerHistory} from './modules/ServerHistory.js';
+import {addRoutePrefix} from './modules/utils.js';
+import type {RouterHistoryType} from './types.js';
 
 type ProviderPropsType = {
-  history: HistoryType,
-  basename: string,
+  history: RouterHistoryType,
+  basename?: string,
+  children?: React.Node,
 };
 
 type HistoryWrapperType = {
   from: (
     ctx: Context
   ) => {
-    history: HistoryType,
+    history: RouterHistoryType,
   },
 };
 
@@ -160,7 +163,7 @@ const plugin: FusionPlugin<PluginDepsType, HistoryWrapperType> = createPlugin({
   provides() {
     return {
       from: memoize(() => {
-        const api: {history: HistoryType} = ({
+        const api: {history: RouterHistoryType} = ({
           history: null,
         }: any);
         return api;

--- a/src/server.js
+++ b/src/server.js
@@ -7,22 +7,49 @@
  */
 
 import {
-  BrowserRouter,
-  HashRouter,
-  Link,
-  MemoryRouter,
-  NavLink,
-  Prompt,
+  BrowserRouter as BrowserRouterUntyped,
+  HashRouter as HashRouterUntyped,
+  Link as LinkUntyped,
+  MemoryRouter as MemoryRouterUntyped,
+  NavLink as NavLinkUntyped,
+  Prompt as PromptUntyped,
   Router as _Router,
-  Switch,
-  matchPath,
-  withRouter,
+  Switch as SwitchUntyped,
+  matchPath as matchPathUntyped,
+  withRouter as withRouterUntyped,
 } from 'react-router-dom';
 
 import {Status, NotFound} from './modules/Status';
 import {Redirect} from './modules/Redirect';
 import {ServerRouter as Router} from './modules/ServerRouter';
 import {Route} from './modules/Route';
+
+import type {
+  BrowserRouterType,
+  HashRouterType,
+  LinkType,
+  MemoryRouterType,
+  NavLinkType,
+  PromptType,
+  SwitchType,
+  matchPathType,
+  withRouterType,
+} from './types.js';
+
+/**
+ * Cast each of these imports from react-router-dom to a copied-version of their
+ * types.  This is necessary as the libdef defined types will not be accessible to
+ * consumers of this package.
+ */
+const BrowserRouter: BrowserRouterType = BrowserRouterUntyped;
+const HashRouter: HashRouterType = HashRouterUntyped;
+const Link: LinkType = LinkUntyped;
+const MemoryRouter: MemoryRouterType = MemoryRouterUntyped;
+const NavLink: NavLinkType = NavLinkUntyped;
+const Prompt: PromptType = PromptUntyped;
+const Switch: SwitchType = SwitchUntyped;
+const matchPath: matchPathType = matchPathUntyped;
+const withRouter: withRouterType = withRouterUntyped;
 
 export {
   BrowserRouter,

--- a/src/types.js
+++ b/src/types.js
@@ -6,6 +6,8 @@
  * @flow
  */
 
+import * as React from 'react';
+
 export type LocationType = {
   pathname: string,
   search: string,
@@ -14,18 +16,173 @@ export type LocationType = {
   key?: string,
 };
 
-type NavigationFunctionType = (
-  path: string,
-  state?: Object
-) => void | (LocationType => void);
+export type LocationShapeType = {
+  pathname?: string,
+  search?: string,
+  hash?: string,
+  state?: Object,
+};
 
-export type HistoryType = {
+/* Types below adapted from flow-typed's libdef for react-router-dom
+ * (https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js)
+ */
+export type BrowserRouterType = React.ComponentType<{|
+  basename?: string,
+  forceRefresh?: boolean,
+  getUserConfirmation?: GetUserConfirmation,
+  keyLength?: number,
+  children?: React.Node,
+|}>;
+
+export type HashRouterType = React.ComponentType<{|
+  basename?: string,
+  getUserConfirmation?: GetUserConfirmation,
+  hashType?: 'slash' | 'noslash' | 'hashbang',
+  children?: React.Node,
+|}>;
+
+export type LinkType = React.ComponentType<{
+  className?: string,
+  to: string | LocationShapeType,
+  replace?: boolean,
+  children?: React.Node,
+}>;
+
+export type NavLinkType = React.ComponentType<{
+  to?: string | LocationShapeType,
+  activeClassName?: string,
+  className?: string,
+  activeStyle?: Object,
+  style?: Object,
+  isActive?: (match: MatchType, location: LocationType) => boolean,
+  children?: React.Node,
+  exact?: boolean,
+  strict?: boolean,
+}>;
+
+// NOTE: Below are mostly duplicated from react-router.
+export type HistoryActionType = 'PUSH' | 'REPLACE' | 'POP';
+
+export type RouterHistoryType = {
   length: number,
   location: LocationType,
-  action: string,
-  push: NavigationFunctionType,
-  replace: NavigationFunctionType,
-  go: (n: number) => void,
-  goBack: () => void,
-  goForward: () => void,
+  action: HistoryActionType,
+  listen(
+    callback: (location: LocationType, action: HistoryActionType) => void
+  ): () => void,
+  push(path: string | LocationShapeType, state?: any): void,
+  replace(path: string | LocationShapeType, state?: any): void,
+  go(n: number): void,
+  goBack(): void,
+  goForward(): void,
+  canGo?: (n: number) => boolean,
+  block(
+    callback: (location: LocationType, action: HistoryActionType) => boolean
+  ): void,
+  // createMemoryHistory
+  index?: number,
+  entries?: Array<LocationType>,
 };
+
+export type MatchType = {
+  params: {[key: string]: ?string},
+  isExact: boolean,
+  path: string,
+  url: string,
+};
+
+type ContextRouter = {|
+  history: RouterHistoryType,
+  location: LocationType,
+  match: MatchType,
+  staticContext?: StaticRouterContextType,
+|};
+
+type ContextRouterVoid = {
+  history: RouterHistoryType | void,
+  location: LocationType | void,
+  match: MatchType | void,
+  staticContext?: StaticRouterContextType | void,
+};
+
+type GetUserConfirmation = (
+  message: string,
+  callback: (confirmed: boolean) => void
+) => void;
+
+export type StaticRouterContextType = {
+  url?: string,
+};
+
+export type StaticRouterType = React.ComponentType<{|
+  basename?: string,
+  location?: string | LocationType,
+  context: StaticRouterContextType,
+  children?: React.Node,
+|}>;
+
+export type MemoryRouterType = React.ComponentType<{|
+  initialEntries?: Array<LocationShapeType | string>,
+  initialIndex?: number,
+  getUserConfirmation?: GetUserConfirmation,
+  keyLength?: number,
+  children?: React.Node,
+|}>;
+
+export type RouterType = React.ComponentType<{
+  history: RouterHistoryType,
+  basename?: string,
+  children?: React.Node,
+}>;
+
+export type PromptType = React.ComponentType<{|
+  message: string | ((location: LocationType) => string | boolean),
+  when?: boolean,
+|}>;
+
+export type RedirectType = React.ComponentType<{|
+  to: string | LocationShapeType,
+  push?: boolean,
+  from?: string,
+  exact?: boolean,
+  strict?: boolean,
+  code?: number | string,
+  children?: React.Node,
+|}>;
+
+export type RouteType = React.ComponentType<{|
+  component?: React.ComponentType<*>,
+  render?: (router: ContextRouter) => React.Node,
+  children?: React.ComponentType<ContextRouter> | React.Node,
+  path?: string | Array<string>,
+  exact?: boolean,
+  strict?: boolean,
+  location?: LocationShapeType,
+  sensitive?: boolean,
+|}>;
+
+export type SwitchType = React.ComponentType<{|
+  children?: React.Node,
+  location?: LocationType,
+|}>;
+
+export type withRouterType = <WrappedComponent: React.ComponentType<*>>(
+  Component: WrappedComponent
+) => React.ComponentType<
+  $Diff<React.ElementConfig<$Supertype<WrappedComponent>>, ContextRouterVoid>
+>;
+
+type MatchPathOptions = {
+  path?: string,
+  exact?: boolean,
+  sensitive?: boolean,
+  strict?: boolean,
+};
+
+export type matchPathType = (
+  pathname: string,
+  options?: MatchPathOptions | string,
+  parent?: MatchType
+) => null | MatchType;
+
+export type generatePathType = (pattern?: string, params?: Object) => string;


### PR DESCRIPTION
A number of improvements to the static types in this package.  Includes:
* Adding missing `libdef` files for a number of dependencies (history, prop-types, react-router-dom, and tape-cup).
* Add missing `libdef` to type globals.
* Improve static types across the board, including passing through relevant dependency types.