### PR TITLE
Fix destructuring bug in Status

### DIFF
--- a/src/modules/Status.js
+++ b/src/modules/Status.js
@@ -14,7 +14,7 @@ type StatusPropsType = {
   code?: string | number,
 };
 type StatusContextType = {
-  router: {
+  router?: {
     staticContext: {
       setCode: (code: number) => void,
     },

--- a/src/modules/Status.js
+++ b/src/modules/Status.js
@@ -24,7 +24,7 @@ export class Status extends React.Component<StatusPropsType> {
   constructor(props: StatusPropsType, context: StatusContextType) {
     super(props, context);
     const {
-      router: {staticContext},
+      router: {staticContext} = {},
     } = context;
     if (staticContext && staticContext.setCode) {
       staticContext.setCode(parseInt(this.props.code, 10));

--- a/src/modules/Status.js
+++ b/src/modules/Status.js
@@ -23,9 +23,7 @@ type StatusContextType = {
 export class Status extends React.Component<StatusPropsType> {
   constructor(props: StatusPropsType, context: StatusContextType) {
     super(props, context);
-    const {
-      router: {staticContext} = {},
-    } = context;
+    const {router: {staticContext} = {}} = context;
     if (staticContext && staticContext.setCode) {
       staticContext.setCode(parseInt(this.props.code, 10));
     }


### PR DESCRIPTION
When Status is rendered in the browser I get `TypeError: Cannot read property 'staticContext' of undefined`. It looks like this is because Status expects `router` to be present as a property of `context`. This is the case for ServerRouter but not for BrowserRouter.

By destructuring with a default value of `{}` for `router`, `staticContext` is correctly set to `undefined` when `router` doesn't exist.