### PR TITLE
Test memory router, ensure Route onRoute is not required

### DIFF
--- a/src/__tests__/memoryrouter.browser.js
+++ b/src/__tests__/memoryrouter.browser.js
@@ -1,0 +1,27 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env browser */
+import test from 'tape-cup';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {MemoryRouter, Route} from '../browser.js';
+
+test('works in browser', t => {
+  const root = document.createElement('div');
+
+  const el = (
+    <MemoryRouter initialEntries={['/test']}>
+      <Route path='/test' render={() => <div>Test</div>} />
+    </MemoryRouter>
+  );
+  ReactDOM.render(el, root);
+  t.ok(/Test/.test(root.innerHTML), 'matches');
+  t.end();
+});

--- a/src/__tests__/memoryrouter.browser.js
+++ b/src/__tests__/memoryrouter.browser.js
@@ -18,7 +18,7 @@ test('works in browser', t => {
 
   const el = (
     <MemoryRouter initialEntries={['/test']}>
-      <Route path='/test' render={() => <div>Test</div>} />
+      <Route path="/test" render={() => <div>Test</div>} />
     </MemoryRouter>
   );
   ReactDOM.render(el, root);

--- a/src/__tests__/memoryrouter.node.js
+++ b/src/__tests__/memoryrouter.node.js
@@ -16,7 +16,7 @@ import {MemoryRouter, Route} from '../server.js';
 test('works in server', t => {
   const el = (
     <MemoryRouter initialEntries={['/test']}>
-      <Route path='/test' render={() => <div>Test</div>} />
+      <Route path="/test" render={() => <div>Test</div>} />
     </MemoryRouter>
   );
   t.ok(/Test/.test(render(el)), 'matches');

--- a/src/__tests__/memoryrouter.node.js
+++ b/src/__tests__/memoryrouter.node.js
@@ -1,0 +1,24 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import test from 'tape-cup';
+import React from 'react';
+
+import {renderToString as render} from 'react-dom/server';
+
+import {MemoryRouter, Route} from '../server.js';
+
+test('works in server', t => {
+  const el = (
+    <MemoryRouter initialEntries={['/test']}>
+      <Route path='/test' render={() => <div>Test</div>} />
+    </MemoryRouter>
+  );
+  t.ok(/Test/.test(render(el)), 'matches');
+  t.end();
+});

--- a/src/modules/Route.js
+++ b/src/modules/Route.js
@@ -36,11 +36,13 @@ function Route(props: PropsType, context: ContextType) {
       children={(routeProps: ContextRouterType) => {
         const {match} = routeProps;
         if (match && match.isExact) {
-          context.onRoute({
-            page: match.path,
-            title: trackingId || match.path,
-            params: match.params,
-          });
+          if (typeof context.onRoute === 'function') {
+            context.onRoute({
+              page: match.path,
+              title: trackingId || match.path,
+              params: match.params,
+            });
+          }
         }
 
         if (component)
@@ -60,7 +62,7 @@ function Route(props: PropsType, context: ContextType) {
 }
 
 Route.contextTypes = {
-  onRoute: PropTypes.func.isRequired,
+  onRoute: PropTypes.func,
 };
 
 Route.displayName = 'FusionRoute';


### PR DESCRIPTION
Currently, using `<MemoryRouter>` causes an error that the `onRoute` context property is required by `<Route>`.

This PR makes onRoute optional and adds tests to ensure basic usage of MemoryRouter works 