### PR TITLE
Change createBrowserHistory imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
   "dependencies": {
-    "history": "^4.7.2",
+    "history": "^4.9.0",
     "prop-types": "^15.6.2",
     "react-router-dom": "^4.3.1"
   },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 import {Router as DefaultProvider} from 'react-router-dom';
-import { createBrowserHistory } from 'history';
+import {createBrowserHistory} from 'history';
 
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 import {Router as DefaultProvider} from 'react-router-dom';
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import {createPlugin, createToken, html, unescape, memoize} from 'fusion-core';


### PR DESCRIPTION
The method of importing createBrowserHistory with `import createBrowserHistory from 'history/createBrowserHistory'` causes warning messages during testing. The message produced below includes an example of how to import the `createBrowserHistory` function. This change updates the code to be compatible with the intent of the message.

```
  console.error node_modules/history/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.
```